### PR TITLE
Added other as an option in time on page pagePaths

### DIFF
--- a/data-updates/notebooks/app_ees_time_on_page.r
+++ b/data-updates/notebooks/app_ees_time_on_page.r
@@ -67,10 +67,23 @@ full_data <- full_data %>%
     str_detect(pagePath, "/glossary") ~ "Glossary",
     str_detect(pagePath, "/cookies") ~ "Cookies",
     str_detect(pagePath, "/") ~ "Homepage",
+    str_detect(pagePath, "(other)") ~ "Other",
     TRUE ~ "NA"
   ))
 
 # COMMAND ----------
+
+if(nrow(full_data %>% filter(page_type == "NA"))>0){
+  message(
+    "Found undocumented pagePath(s):", 
+    paste(
+      full_data |>
+        dplyr::filter(page_type == "NA") |>
+        dplyr::pull(pagePath) |>
+        unique(),
+      collapse = ","
+    ))
+}
 
 test_that("There are no events without a page type classification", {
   expect_true(nrow(full_data %>% filter(page_type == "NA")) == 0)


### PR DESCRIPTION
## Overview of changes

The pipeline was erroring on identifying a new pagePath with the available page types. It looks like it's not a full URL, but just "(other)". Not sure what this is, but putting in some code to handle it and we can check back what it's actually picking up on.

## Why are these changes being made?

To get the pipeline working again.

## Checklist

